### PR TITLE
feat: add custom 404 page with error message and recent entries section

### DIFF
--- a/docshub/src/pages/404.astro
+++ b/docshub/src/pages/404.astro
@@ -1,0 +1,38 @@
+---
+import LayoutMain from "@/layouts/layoutMain.astro";
+import LastEntries from "@/components/last-entries.astro";
+
+const currentUrl = new URL(Astro.request.url);
+const path = currentUrl.pathname;
+---
+
+<LayoutMain
+  title={"Page Not Found"}
+  description={"Page not found, but don't worry!"}
+>
+  <div
+    class="container mx-auto max-w-5xl p-6 md:h-[calc(100vh-65px)] flex flex-col justify-center items-center"
+  >
+    <header class="space-y-4">
+      <section class="space-y-2 text-center">
+        <h1 class="text-5xl font-extrabold text-gray-800 dark:text-gray-300">
+          404
+        </h1>
+        <p class="text-lg text-gray-500 dark:text-gray-200 text-center">
+          We couldn’t find the page at
+          <code class="font-mono italic text-gray-700 dark:text-gray-400"
+            >{path}</code
+          >
+        </p>
+      </section>
+
+      <p
+        class="font-medium text-gray-600 dark:text-gray-300 text-lg text-center"
+      >
+        Oops! It's like a glitch in the Matrix...
+      </p>
+
+      <LastEntries />
+    </header>
+  </div>
+</LayoutMain>


### PR DESCRIPTION
Added a custom 404 page to replace the default, provided by Astro. The new page informs users that something went wrong with the attempt to access a non-existent URL and suggests last entrie' as an alternative for navigation.

![test_404_dark](https://github.com/user-attachments/assets/c49f9800-a768-4862-95b3-d9e42ec9c32b)
![test_404_light](https://github.com/user-attachments/assets/1337505d-5ca2-4ec9-bbf9-c9bc1c2666f7)
